### PR TITLE
Merging agelimits

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -10,11 +10,15 @@ module.exports = function (grunt) {
     if ( (typeof(grunt.option("language")) === "undefined") ) {
         console.log("INFO: No language chosen, assuming nl");
     }
+    if ( (typeof(grunt.option("idin_credential_id")) === "undefined") ) {
+        console.log("INFO: No idin_credential_id chosen, assuming pbdf.pbdf.idin");
+    }
 
     var conf = {
         idin_server_url: grunt.option("idin_server_url") || "<IDIN_SERVER_URL>",
         irma_server_url: grunt.option("irma_server_url") || "<IRMA_SERVER_URL>",
         language: grunt.option("language") || "nl",
+        idin_credential_id: grunt.option("idin_credential_id") || "pbdf.pbdf.idin",
     };
     conf.irma_server_url += "/api/v2";
 

--- a/src/enroll.html
+++ b/src/enroll.html
@@ -31,19 +31,17 @@
 
             <div id="alert_box"></div>
 
-            <div style="display: none">
             <p><%= enroll_received_attributes %></p>
             <table class="table" id="idinTable">
                 <tbody></tbody>
             </table>
-            </div>
             <br/>
-            <div style="display: none">
             <p><%= enroll_derived_attributes %></p>
             <table class="table" id="ageTable">
                 <tbody></tbody>
             </table>
-            </div>
+
+            <p id="twoCredentialsWarning" style="display: none"><i><%= enroll_two_credentials_warning %></i></p>
 
             <p><%= enroll_clicktoload %></p>
             <button id="enroll" class="btn btn-primary"><%= enroll_load_button %></button>

--- a/src/enroll.html
+++ b/src/enroll.html
@@ -31,15 +31,19 @@
 
             <div id="alert_box"></div>
 
+            <div style="display: none">
             <p><%= enroll_received_attributes %></p>
             <table class="table" id="idinTable">
                 <tbody></tbody>
             </table>
+            </div>
             <br/>
+            <div style="display: none">
             <p><%= enroll_derived_attributes %></p>
             <table class="table" id="ageTable">
                 <tbody></tbody>
             </table>
+            </div>
 
             <p><%= enroll_clicktoload %></p>
             <button id="enroll" class="btn btn-primary"><%= enroll_load_button %></button>

--- a/src/js/iDIN-enroll.js
+++ b/src/js/iDIN-enroll.js
@@ -9,6 +9,7 @@ getSetupFromJson(function() {
                     .append($('<td>').text(data)
                     )
                 );
+            table.parent().show();
         }
     }
 

--- a/src/js/iDIN-enroll.js
+++ b/src/js/iDIN-enroll.js
@@ -9,7 +9,6 @@ getSetupFromJson(function() {
                     .append($('<td>').text(data)
                     )
                 );
-            table.parent().show();
         }
     }
 
@@ -18,12 +17,14 @@ getSetupFromJson(function() {
         $.each(creds, function(i, cred) {
             if (cred.credential === conf.idin_credential_id){
                 $.each(cred.attributes, function(key, value) {
-                    addTableLine($('#idinTable'), strings.hasOwnProperty("attribute_" + key) ? strings["attribute_" + key] : key, value);
+                    if (key.includes("over")) {
+                        addTableLine($('#ageTable'), strings.hasOwnProperty("attribute_" + key) ? strings["attribute_" + key] : key, value);
+                    } else {
+                        addTableLine($('#idinTable'), strings.hasOwnProperty("attribute_" + key) ? strings["attribute_" + key] : key, value);
+                    }
                 });
             } else {
-                $.each(cred.attributes, function(key, value) {
-                    addTableLine($('#ageTable'), strings.hasOwnProperty("attribute_" + key) ? strings["attribute_" + key] : key, value);
-                });
+                $('#twoCredentialsWarning').show();
             }
         });
     }

--- a/src/js/iDIN-enroll.js
+++ b/src/js/iDIN-enroll.js
@@ -16,7 +16,7 @@ getSetupFromJson(function() {
 
     function displayAttributes (creds) {
         $.each(creds, function(i, cred) {
-            if (cred.credential === "pbdf.pbdf.idin"){
+            if (cred.credential === conf.idin_credential_id){
                 $.each(cred.attributes, function(key, value) {
                     addTableLine($('#idinTable'), strings.hasOwnProperty("attribute_" + key) ? strings["attribute_" + key] : key, value);
                 });

--- a/src/js/iDIN-verify.js
+++ b/src/js/iDIN-verify.js
@@ -2,7 +2,7 @@ getSetupFromJson(function() {
     var success_fun = function(data) {
         $("#result_status").html(strings.verify_success);
         $("#result_header").html(strings.verify_result);
-        var bd = jwt_decode(data).attributes["pbdf.pbdf.idin.dateofbirth"];
+        var bd = jwt_decode(data).attributes[conf.idin_credential_id + ".dateofbirth"];
         $("#token-content").html("<b>" + strings.verify_birthdate + "</b> " + bd);
         //TODO: check for birthdate
     }

--- a/src/languages/en.json
+++ b/src/languages/en.json
@@ -12,7 +12,7 @@
 	"enroll_header": "Beschikbare attributen",
 	"enroll_received_attributes": "De volgende attributen zijn beschikbaar gesteld door uw bank:",
 	"enroll_derived_attributes": "De volgende attributen zijn daaruit afgeleid:",
-	"enroll_two_credentials_warning": "In de IRMA app wordt geen onderscheid meer gemaakt tussen de beschikbaar gestelde atributen en de afgeleide attributen. Om de overgang van deze verandering soepel te laten verlopen, worden de afgeleide attributen tijdelijk dubbel door ons uitgegeven; eenmaal als onderdeel van het geheel van iDIN attributen en eenmaal los.",
+	"enroll_two_credentials_warning": "In november 2019 is een verandering in de structuur van de iDIN attributen in de IRMA-app doorgevoerd, waarbij leeftijdsgrenzen niet meer apart staan. Om deze verandering soepel te laten verlopen, worden deze leeftijdsgrenzen tijdelijk dubbel uitgegeven: eenmaal als onderdeel van het geheel van iDIN attributen en eenmaal los. Vanaf november 2020, als alle attributen in de oude structuur verlopen zijn, zal de uitgifte van de losse leeftijdsgrensattributen definitief worden uitgefaseerd.",
 	"enroll_clicktoload": "Klik de Laad attributen knop om deze attributen in uw IRMA app te laden.",
 	"enroll_load_button": "Laad attributen in uw IRMA app",
 	"done_title": "iDIN Attributen uitgegeven",

--- a/src/languages/en.json
+++ b/src/languages/en.json
@@ -12,6 +12,7 @@
 	"enroll_header": "Beschikbare attributen",
 	"enroll_received_attributes": "De volgende attributen zijn beschikbaar gesteld door uw bank:",
 	"enroll_derived_attributes": "De volgende attributen zijn daaruit afgeleid:",
+	"enroll_two_credentials_warning": "In de IRMA app wordt geen onderscheid meer gemaakt tussen de beschikbaar gestelde atributen en de afgeleide attributen. Om de overgang van deze verandering soepel te laten verlopen, worden de afgeleide attributen tijdelijk dubbel door ons uitgegeven; eenmaal als onderdeel van het geheel van iDIN attributen en eenmaal los.",
 	"enroll_clicktoload": "Klik de Laad attributen knop om deze attributen in uw IRMA app te laden.",
 	"enroll_load_button": "Laad attributen in uw IRMA app",
 	"done_title": "iDIN Attributen uitgegeven",

--- a/src/languages/en.json
+++ b/src/languages/en.json
@@ -12,7 +12,7 @@
 	"enroll_header": "Beschikbare attributen",
 	"enroll_received_attributes": "De volgende attributen zijn beschikbaar gesteld door uw bank:",
 	"enroll_derived_attributes": "De volgende attributen zijn daaruit afgeleid:",
-	"enroll_two_credentials_warning": "In november 2019 is een verandering in de structuur van de iDIN attributen in de IRMA-app doorgevoerd, waarbij leeftijdsgrenzen niet meer apart staan. Om deze verandering soepel te laten verlopen, worden deze leeftijdsgrenzen tijdelijk dubbel uitgegeven: eenmaal als onderdeel van het geheel van iDIN attributen en eenmaal los. Vanaf november 2020, als alle attributen in de oude structuur verlopen zijn, zal de uitgifte van de losse leeftijdsgrensattributen definitief worden uitgefaseerd.",
+	"enroll_two_credentials_warning": "In november 2019 is een verandering in de structuur van de iDIN attributen in de IRMA-app doorgevoerd, waarbij leeftijdsgrenzen niet meer apart staan. Om deze verandering soepel te laten verlopen, worden deze leeftijdsgrenzen tijdelijk dubbel uitgegeven: eenmaal als onderdeel van het geheel van iDIN attributen en eenmaal los. In de loop van 2020 zal de uitgifte van de losse leeftijdsgrensattributen definitief worden uitgefaseerd.",
 	"enroll_clicktoload": "Klik de Laad attributen knop om deze attributen in uw IRMA app te laden.",
 	"enroll_load_button": "Laad attributen in uw IRMA app",
 	"done_title": "iDIN Attributen uitgegeven",

--- a/src/languages/nl.json
+++ b/src/languages/nl.json
@@ -12,7 +12,7 @@
 	"enroll_header": "Beschikbare attributen",
 	"enroll_received_attributes": "De volgende attributen zijn beschikbaar gesteld door uw bank:",
 	"enroll_derived_attributes": "De volgende attributen zijn daaruit afgeleid:",
-	"enroll_two_credentials_warning": "In de IRMA app wordt geen onderscheid meer gemaakt tussen de beschikbaar gestelde atributen en de afgeleide attributen. Om de overgang van deze verandering soepel te laten verlopen, worden de afgeleide attributen tijdelijk dubbel door ons uitgegeven; eenmaal als onderdeel van het geheel van iDIN attributen en eenmaal los.",
+	"enroll_two_credentials_warning": "In november 2019 is een verandering in de structuur van de iDIN attributen in de IRMA-app doorgevoerd, waarbij leeftijdsgrenzen niet meer apart staan. Om deze verandering soepel te laten verlopen, worden deze leeftijdsgrenzen tijdelijk dubbel uitgegeven: eenmaal als onderdeel van het geheel van iDIN attributen en eenmaal los. Vanaf november 2020, als alle attributen in de oude structuur verlopen zijn, zal de uitgifte van de losse leeftijdsgrensattributen definitief worden uitgefaseerd.",
 	"enroll_clicktoload": "Klik de Laad attributen knop om deze attributen in uw IRMA app te laden.",
 	"enroll_load_button": "Laad attributen in uw IRMA app",
 	"done_title": "iDIN Attributen uitgegeven",

--- a/src/languages/nl.json
+++ b/src/languages/nl.json
@@ -12,6 +12,7 @@
 	"enroll_header": "Beschikbare attributen",
 	"enroll_received_attributes": "De volgende attributen zijn beschikbaar gesteld door uw bank:",
 	"enroll_derived_attributes": "De volgende attributen zijn daaruit afgeleid:",
+	"enroll_two_credentials_warning": "In de IRMA app wordt geen onderscheid meer gemaakt tussen de beschikbaar gestelde atributen en de afgeleide attributen. Om de overgang van deze verandering soepel te laten verlopen, worden de afgeleide attributen tijdelijk dubbel door ons uitgegeven; eenmaal als onderdeel van het geheel van iDIN attributen en eenmaal los.",
 	"enroll_clicktoload": "Klik de Laad attributen knop om deze attributen in uw IRMA app te laden.",
 	"enroll_load_button": "Laad attributen in uw IRMA app",
 	"done_title": "iDIN Attributen uitgegeven",

--- a/src/languages/nl.json
+++ b/src/languages/nl.json
@@ -12,7 +12,7 @@
 	"enroll_header": "Beschikbare attributen",
 	"enroll_received_attributes": "De volgende attributen zijn beschikbaar gesteld door uw bank:",
 	"enroll_derived_attributes": "De volgende attributen zijn daaruit afgeleid:",
-	"enroll_two_credentials_warning": "In november 2019 is een verandering in de structuur van de iDIN attributen in de IRMA-app doorgevoerd, waarbij leeftijdsgrenzen niet meer apart staan. Om deze verandering soepel te laten verlopen, worden deze leeftijdsgrenzen tijdelijk dubbel uitgegeven: eenmaal als onderdeel van het geheel van iDIN attributen en eenmaal los. Vanaf november 2020, als alle attributen in de oude structuur verlopen zijn, zal de uitgifte van de losse leeftijdsgrensattributen definitief worden uitgefaseerd.",
+	"enroll_two_credentials_warning": "In november 2019 is een verandering in de structuur van de iDIN attributen in de IRMA-app doorgevoerd, waarbij leeftijdsgrenzen niet meer apart staan. Om deze verandering soepel te laten verlopen, worden deze leeftijdsgrenzen tijdelijk dubbel uitgegeven: eenmaal als onderdeel van het geheel van iDIN attributen en eenmaal los. In de loop van 2020 zal de uitgifte van de losse leeftijdsgrensattributen definitief worden uitgefaseerd.",
 	"enroll_clicktoload": "Klik de Laad attributen knop om deze attributen in uw IRMA app te laden.",
 	"enroll_load_button": "Laad attributen in uw IRMA app",
 	"done_title": "iDIN Attributen uitgegeven",


### PR DESCRIPTION
Include the ageLimit attributes in the main iDIN credential instead of having a separate credential with ageLimits, exactly in line with the ageLimits in the `gemeente.personalData` credential.